### PR TITLE
Tornar o projeto executavel #9

### DIFF
--- a/dundie/__main__.py
+++ b/dundie/__main__.py
@@ -1,0 +1,2 @@
+def main():
+    print("Executing dundie from entry point.")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup, find_packages
+
+
+setup(
+    name="dundie",
+    version="0.1.0",
+    description="Reward Point System for Dunder Mifflin",
+    author="Rodrigo Azevedo",
+    packages=find_packages(),
+    entry_points={"console_scripts": ["dundie = dundie.__main__:main"]},
+)


### PR DESCRIPTION
Fazer com que `dundie` seja um comando CLI valido.

- dundie
- python -m dundie